### PR TITLE
remove infinite loop getting options

### DIFF
--- a/plmcat.c
+++ b/plmcat.c
@@ -41,7 +41,7 @@ void broken_pipe(int sig)
 }
 
 int main(int argc, char **argv) {
-	int TTYFD,nfds,ready,i=0;
+	int TTYFD,nfds,ready,i=0,ret;
 	FILE *ttyfd;
 	char c,buff[128],tbuff[128];
 	struct termios newtio;
@@ -55,8 +55,8 @@ int main(int argc, char **argv) {
 //	timeout.tv_nsec=0;
 
 	// Parse command line using getopt() from libc
-while (255 != (c = getopt(argc,argv,options))) {
-		switch (c) {
+while (-1 != (ret = getopt(argc,argv,options))) {
+		switch (ret) {
 		case 'd':
 			ttylinename = optarg;
 			break;
@@ -123,6 +123,10 @@ argv[0]);
 		FD_SET(TTYFD,&readfds);
 //		ready = pselect(nfds,&readfds,NULL,NULL,&timeout,NULL);
 		ready = pselect(nfds,&readfds,NULL,NULL,NULL,NULL);
+		if(ready == -1) {
+                	fprintf(stderr,"pselect failed with error %i\n",errno);
+               		exit(-1);
+		}
 		if (FD_ISSET(TTYFD,&readfds)) {
 			fgets(buff,127,ttyfd);
 			if ((uc)buff[0] == 0x02 && (uc)buff[1] == 0x52) {

--- a/plmsend.c
+++ b/plmsend.c
@@ -34,7 +34,7 @@ extern char *ttylinename;
 char *options = "d:e:t:vh";
 
 int main(int argc, char **argv) {
-	int ttyfd,nfds,ready;
+	int ttyfd,nfds,ready,ret;
 	char c,*str,*cp,buff[128];
 	struct termios newtio;
 	fd_set readfds;
@@ -49,11 +49,9 @@ int main(int argc, char **argv) {
 
 	struct timespec sleeptime;
 
-	str = &c; // not really, but this suppresses a compiler warning
-
 	// Parse command line using getopt() from libc
-while (255 != (c = getopt(argc,argv,options))) {
-		switch (c) {
+while (-1 != (ret = getopt(argc,argv,options))) {
+		switch (ret) {
 		case 'd':
 			ttylinename = optarg;
 			break;
@@ -190,6 +188,10 @@ argv[0]);
 
 	// sleep for a while unless data arrives
 	ready = pselect(nfds,&readfds,NULL,NULL,&sleeptime,NULL);
+	if(ready == -1) {
+		fprintf(stderr,"pselect failed with error %i\n",errno);
+		exit(-1);
+	}
 	while (0 < read(ttyfd,&c,1)) {
 		outhex(STDOUT,c);
 		wrote = TRUE;


### PR DESCRIPTION
Compiling current version on Fedora 33 x86_64 gives (from plmsend.c for example)

```
cc -Os -g -Wall  -W -Wshadow -c plmsend.c
plmsend.c: In function ‘main’:
plmsend.c:55:12: warning: comparison is always true due to limited range of data type [-Wtype-limits]
   55 | while (255 != (c = getopt(argc,argv,options))) {
      |            ^~
plmsend.c:37:17: warning: variable ‘ready’ set but not used [-Wunused-but-set-variable]
   37 |  int ttyfd,nfds,ready;
      |                 ^~~~~
```

that first warning about always true results in an infinite loop getting command line options for all three programs.  Needed change is return from getopt() into an int and compare to -1 for end of options.

The warning about ready unused does not give any bad behavior, but I added code to check this value and exit with an error message in all the calls to pselect() that return into ready.  Always check the return value is one of my mottos.

Been using plmtools for many years now to run my house lights automation.  

Thanks,

Tom